### PR TITLE
Remove sklearn FutureWarning

### DIFF
--- a/polyssifier/poly_utils.py
+++ b/polyssifier/poly_utils.py
@@ -125,14 +125,14 @@ def build_classifiers(exclude, scale, feature_selection, nCols):
     if 'Decision Tree' not in exclude:
         classifiers['Decision Tree'] = {
             'clf': DecisionTreeClassifier(max_depth=None,
-                                          max_features='auto'),
+                                          max_features='sqrt'),
             'parameters': {}}
 
     if 'Random Forest' not in exclude:
         classifiers['Random Forest'] = {
             'clf': RandomForestClassifier(max_depth=None,
                                           n_estimators=10,
-                                          max_features='auto'),
+                                          max_features='sqrt'),
             'parameters': {'n_estimators': list(range(5, 20))}}
 
     if 'Logistic Regression' not in exclude:


### PR DESCRIPTION
Versions installed:
Python 3.8.10
scikit-learn==1.1.2

Warning:
```
lib/python3.8/site-packages/sklearn/ensemble/_forest.py:427: FutureWarning: `max_features='auto'` has been deprecated in 1.1 and will be removed in 1.3. To keep the past behaviour, explicitly set `max_features='sqrt'` or remove this parameter as it is also the default value for RandomForestClassifiers and ExtraTreesClassifiers.
```