### PR TITLE
Remove matplotlib rotation ValueError

### DIFF
--- a/polyssifier/report.py
+++ b/polyssifier/report.py
@@ -143,7 +143,7 @@ def plot_scores(scores, scoring='auc', file_name='temp', min_val=None):
             break
         ax1.text(rect.get_x() - rect.get_width() / 2., ymin + (1 - ymin) * .01,
                  data.index[n], ha='center', va='bottom',
-                 rotation='90', color='black', fontsize=15)
+                 rotation=90, color='black', fontsize=15)
     plt.tight_layout()
     plt.savefig(file_name + '.pdf')
     plt.savefig(file_name + '.svg', transparent=False)


### PR DESCRIPTION
Versions installed:
Python 3.8.10
matplotlib==3.6.0

Error:
```
ValueError: rotation must be 'vertical', 'horizontal' or a number, not 90
```